### PR TITLE
feature: Adds support for mapping php enums

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,20 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true"
->
-    <php>
-        <env name="DB_CONNECTION" value="testing"/>
-    </php>
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <php>
+    <env name="DB_CONNECTION" value="testing"/>
+  </php>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage/>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/ColumnPropertyService.php
+++ b/src/ColumnPropertyService.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace AdventureTech\ORM;
+
+use AdventureTech\ORM\Exceptions\EntityReflectionInstantiationException;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionProperty;
+
+class ColumnPropertyService
+{
+    /**
+     * Test if the property of the column being mapped is an enum
+     *
+     * @param  ReflectionProperty  $property
+     * @return bool
+     */
+    public static function isEnum(ReflectionProperty $property): bool
+    {
+        if ($property->getType()->isBuiltin()) {
+            return false;
+        }
+
+        try {
+            $reflectionClass = new RefLectionClass($property->getType()->getName());
+        } catch (ReflectionException) {
+            throw new EntityReflectionInstantiationException($property->getType()->getName());
+        }
+
+        return $reflectionClass->isEnum();
+    }
+}

--- a/src/ColumnPropertyService.php
+++ b/src/ColumnPropertyService.php
@@ -2,31 +2,63 @@
 
 namespace AdventureTech\ORM;
 
-use AdventureTech\ORM\Exceptions\EntityReflectionInstantiationException;
+use AdventureTech\ORM\Exceptions\UnsupportedReflectionTypeException;
 use ReflectionClass;
 use ReflectionException;
+use ReflectionNamedType;
 use ReflectionProperty;
 
 class ColumnPropertyService
 {
     /**
-     * Test if the property of the column being mapped is an enum
+     * Check if the Property is nullable
      *
      * @param  ReflectionProperty  $property
      * @return bool
      */
+    public static function allowsNull(ReflectionProperty $property): bool
+    {
+        return self::getReflectionType($property)->allowsNull();
+    }
+
+    /**
+     * Return the property type name
+     *
+     * @param  ReflectionProperty  $property
+     * @return string
+     */
+    public static function getPropertyType(ReflectionProperty $property): string
+    {
+        return self::getReflectionType($property)->getName();
+    }
+
+    /**
+     * Check if the Property is an enum
+     *
+     * @param  ReflectionProperty  $property
+     * @return bool
+     * @throws ReflectionException
+     */
     public static function isEnum(ReflectionProperty $property): bool
     {
-        if ($property->getType()->isBuiltin()) {
+        $type = self::getReflectionType($property);
+        if ($type->isBuiltin()) {
             return false;
         }
 
-        try {
-            $reflectionClass = new RefLectionClass($property->getType()->getName());
-        } catch (ReflectionException) {
-            throw new EntityReflectionInstantiationException($property->getType()->getName());
-        }
+        /** @var class-string $className */
+        $className = $type->getName();
+        $reflectionClass = new RefLectionClass($className);
 
         return $reflectionClass->isEnum();
+    }
+
+    private static function getReflectionType(ReflectionProperty $property): ReflectionNamedType
+    {
+        $type = $property->getType();
+        if (!($type instanceof ReflectionNamedType)) {
+            throw new UnsupportedReflectionTypeException();
+        }
+        return $type;
     }
 }

--- a/src/EntityReflection.php
+++ b/src/EntityReflection.php
@@ -5,7 +5,6 @@ namespace AdventureTech\ORM;
 use AdventureTech\ORM\Exceptions\EntityInstantiationException;
 use AdventureTech\ORM\Exceptions\EntityReflectionInstantiationException;
 use AdventureTech\ORM\Exceptions\MultipleIdColumnsException;
-use AdventureTech\ORM\Exceptions\UnsupportedReflectionTypeException;
 use AdventureTech\ORM\Factories\Factory;
 use AdventureTech\ORM\Mapping\Columns\ColumnAnnotation;
 use AdventureTech\ORM\Mapping\Entity;
@@ -23,7 +22,6 @@ use Mockery;
 use Mockery\Mock;
 use ReflectionClass;
 use ReflectionException;
-use ReflectionNamedType;
 use ReflectionProperty;
 
 /**
@@ -83,7 +81,7 @@ class EntityReflection
     /**
      * @return Mock|EntityReflection<object>
      */
-    public static function fake(): Mock | EntityReflection
+    public static function fake(): Mock|EntityReflection
     {
         self::$fake = Mockery::mock(self::class)->makePartial();
         return self::$fake;
@@ -267,7 +265,7 @@ class EntityReflection
     private function registerLinker(RelationAnnotation $relationAnnotation, ReflectionProperty $property): void
     {
         $propertyName = $property->getName();
-        /** @var class-string<object> $propertyType */
+        /** @var class-string $propertyType */
         $propertyType = $this->getPropertyType($propertyName);
         $this->linkers->put(
             $propertyName,
@@ -277,20 +275,11 @@ class EntityReflection
 
     public function allowsNull(string $property): bool
     {
-        return $this->getReflectionType($property)->allowsNull();
+        return ColumnPropertyService::allowsNull($this->reflectionClass->getProperty($property));
     }
 
     public function getPropertyType(string $property): string
     {
-        return $this->getReflectionType($property)->getName();
-    }
-
-    private function getReflectionType(string $property): ReflectionNamedType
-    {
-        $type = $this->reflectionClass->getProperty($property)->getType();
-        if (!($type instanceof ReflectionNamedType)) {
-            throw new UnsupportedReflectionTypeException();
-        }
-        return $type;
+        return ColumnPropertyService::getPropertyType($this->reflectionClass->getProperty($property));
     }
 }

--- a/src/Exceptions/EnumSerializationException.php
+++ b/src/Exceptions/EnumSerializationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace AdventureTech\ORM\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+class EnumSerializationException extends RuntimeException
+{
+    public function __construct(
+        string $message = 'Only native Enum can be serialized.',
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Factories/Factory.php
+++ b/src/Factories/Factory.php
@@ -2,6 +2,7 @@
 
 namespace AdventureTech\ORM\Factories;
 
+use AdventureTech\ORM\ColumnPropertyService;
 use AdventureTech\ORM\EntityAccessorService;
 use AdventureTech\ORM\EntityReflection;
 use AdventureTech\ORM\Mapping\Linkers\OwningLinker;
@@ -9,6 +10,7 @@ use AdventureTech\ORM\Persistence\PersistenceManager;
 use Carbon\CarbonImmutable;
 use Faker\Generator;
 use Illuminate\Support\Collection;
+use ReflectionProperty;
 
 /**
  * @template T of object
@@ -117,7 +119,13 @@ class Factory
         if ($this->entityReflection->allowsNull($property)) {
             return null;
         }
+
         $type = $this->entityReflection->getPropertyType($property);
+
+        $property = new ReflectionProperty($this->entityReflection->getClass(), $property);
+        if (ColumnPropertyService::isEnum($property)) {
+            return $this->faker->randomElement($type::cases());
+        }
         return match ($type) {
             'int' => $this->faker->randomNumber(),
             'float' => $this->faker->randomFloat(),

--- a/src/Mapping/Columns/Column.php
+++ b/src/Mapping/Columns/Column.php
@@ -35,7 +35,7 @@ readonly class Column implements ColumnAnnotation
 
     /**
      * @param  ReflectionProperty  $property
-     * @return DefaultMapper<T>|JSONMapper|DatetimeMapper
+     * @return DefaultMapper<T>|JSONMapper|DatetimeMapper|EnumMapper
      */
     public function getMapper(ReflectionProperty $property): Mapper
     {

--- a/src/Mapping/Columns/Column.php
+++ b/src/Mapping/Columns/Column.php
@@ -6,9 +6,11 @@
 
 namespace AdventureTech\ORM\Mapping\Columns;
 
+use AdventureTech\ORM\ColumnPropertyService;
 use AdventureTech\ORM\DefaultNamingService;
 use AdventureTech\ORM\Mapping\Mappers\DatetimeMapper;
 use AdventureTech\ORM\Mapping\Mappers\DefaultMapper;
+use AdventureTech\ORM\Mapping\Mappers\EnumMapper;
 use AdventureTech\ORM\Mapping\Mappers\JSONMapper;
 use AdventureTech\ORM\Mapping\Mappers\Mapper;
 use Attribute;
@@ -20,7 +22,6 @@ use ReflectionProperty;
  * @template T
  * @implements ColumnAnnotation<T>
  */
-
 #[Attribute(Attribute::TARGET_PROPERTY)]
 readonly class Column implements ColumnAnnotation
 {
@@ -41,6 +42,10 @@ readonly class Column implements ColumnAnnotation
         $name = $this->name ?? DefaultNamingService::columnFromProperty($property->getName());
         /** @var ReflectionNamedType $reflectionNamedType */
         $reflectionNamedType = $property->getType();
+
+        if (ColumnPropertyService::isEnum($property)) {
+            return new EnumMapper($name, $property);
+        }
         return match ($reflectionNamedType->getName()) {
             CarbonImmutable::class => new DatetimeMapper($name),
             'array' => new JSONMapper($name),

--- a/src/Mapping/Mappers/DatetimeMapper.php
+++ b/src/Mapping/Mappers/DatetimeMapper.php
@@ -8,7 +8,6 @@ namespace AdventureTech\ORM\Mapping\Mappers;
 
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
 use Carbon\CarbonImmutable;
-use ReflectionProperty;
 use stdClass;
 
 /**

--- a/src/Mapping/Mappers/DefaultMapper.php
+++ b/src/Mapping/Mappers/DefaultMapper.php
@@ -7,7 +7,6 @@
 namespace AdventureTech\ORM\Mapping\Mappers;
 
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
-use ReflectionProperty;
 use stdClass;
 
 /**

--- a/src/Mapping/Mappers/EnumMapper.php
+++ b/src/Mapping/Mappers/EnumMapper.php
@@ -1,26 +1,54 @@
 <?php
 
+/**
+ *
+ */
+
 namespace AdventureTech\ORM\Mapping\Mappers;
 
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
+use AdventureTech\ORM\ColumnPropertyService;
+use AdventureTech\ORM\Exceptions\EnumSerializationException;
+use ReflectionProperty;
 use stdClass;
+use UnitEnum;
+
+/**
+ * @implements Mapper<array>
+ */
 
 readonly class EnumMapper implements Mapper
 {
     private string $enumClassName;
 
+    /**
+     * @param  string  $name
+     * @param  ReflectionProperty  $property
+     */
     public function __construct(
         private string $name,
-        private \ReflectionProperty $property
+        private ReflectionProperty $property
     ) {
-        $this->enumClassName = $this->property->getType()->getName();
+        $this->enumClassName = ColumnPropertyService::getPropertyType($this->property);
     }
 
+    /**
+     * @param  null|UnitEnum  $value
+     * @return null[]
+     */
     public function serialize(mixed $value): array
     {
+        if (!is_null($value) && (!is_object($value) || !enum_exists($value::class))) {
+            throw new EnumSerializationException();
+        }
         return [$this->name => $value->value ?? null];
     }
 
+    /**
+     * @param  stdClass  $item
+     * @param  LocalAliasingManager  $aliasingManager
+     * @return UnitEnum|null
+     */
     public function deserialize(stdClass $item, LocalAliasingManager $aliasingManager): mixed
     {
         $value = $item->{$aliasingManager->getSelectedColumnName($this->name)};

--- a/src/Mapping/Mappers/EnumMapper.php
+++ b/src/Mapping/Mappers/EnumMapper.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace AdventureTech\ORM\Mapping\Mappers;
+
+use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
+use stdClass;
+
+readonly class EnumMapper implements Mapper
+{
+    private string $enumClassName;
+
+    public function __construct(
+        private string $name,
+        private \ReflectionProperty $property
+    ) {
+        $this->enumClassName = $this->property->getType()->getName();
+    }
+
+    public function serialize(mixed $value): array
+    {
+        return [$this->name => $value->value ?? null];
+    }
+
+    public function deserialize(stdClass $item, LocalAliasingManager $aliasingManager): mixed
+    {
+        $value = $item->{$aliasingManager->getSelectedColumnName($this->name)};
+
+        return is_null($value) ? $value : $this->enumClassName::from($value);
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    public function getColumnNames(): array
+    {
+        return [$this->name];
+    }
+}

--- a/src/Mapping/Mappers/JSONMapper.php
+++ b/src/Mapping/Mappers/JSONMapper.php
@@ -9,7 +9,6 @@ namespace AdventureTech\ORM\Mapping\Mappers;
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
 use AdventureTech\ORM\Exceptions\JSONDeserializationException;
 use JsonException;
-use ReflectionProperty;
 use stdClass;
 
 /**

--- a/tests/Feature/EntityReflectionTest.php
+++ b/tests/Feature/EntityReflectionTest.php
@@ -98,6 +98,7 @@ test('Can names of selected columns correctly with owning linker (BelongsTo)', f
             'id',
             'title',
             'content',
+            'number',
             'published_at',
             'published_tz',
             'created_at',

--- a/tests/Feature/Factories/FactoryTest.php
+++ b/tests/Feature/Factories/FactoryTest.php
@@ -1,8 +1,10 @@
 <?php
 
 use AdventureTech\ORM\Factories\Factory;
+use AdventureTech\ORM\Tests\TestClasses\Entities\Number;
 use AdventureTech\ORM\Tests\TestClasses\Entities\Post;
 use AdventureTech\ORM\Tests\TestClasses\Entities\User;
+use AdventureTech\ORM\Tests\TestClasses\IntEnum;
 use Illuminate\Support\Facades\DB;
 
 test('Can create single entity', function () {
@@ -22,6 +24,12 @@ test('Can set owning relations as instances', function () {
         'editor' => $editor
     ]);
     expect(DB::table('posts')->first()->editor)->toBe($editor->getId());
+});
+
+test('Can create entity with enum', function (){
+  $number = Factory::new(Post::class)->create();
+
+  expect($number->number)->toBeIn(IntEnum::cases());
 });
 
 test('Can set owning relations as factories', function () {

--- a/tests/Feature/Persistence/PersistenceInsertTest.php
+++ b/tests/Feature/Persistence/PersistenceInsertTest.php
@@ -9,6 +9,7 @@ use AdventureTech\ORM\Exceptions\MissingValueForColumnException;
 use AdventureTech\ORM\Persistence\PersistenceManager;
 use AdventureTech\ORM\Tests\TestClasses\Entities\Post;
 use AdventureTech\ORM\Tests\TestClasses\Entities\User;
+use AdventureTech\ORM\Tests\TestClasses\IntEnum;
 use AdventureTech\ORM\Tests\TestClasses\Persistence\PostPersistence;
 use AdventureTech\ORM\Tests\TestClasses\Persistence\UserPersistence;
 use Carbon\CarbonImmutable;
@@ -114,6 +115,7 @@ test('Can insert owning relations', function () {
     $post->content = 'Content';
     $post->author = $author;
     $post->editor = $editor;
+    $post->number = IntEnum::ONE;
 
     PostPersistence::insert($post);
 
@@ -126,6 +128,7 @@ test('Must set owning relation', function () {
     $post = new Post();
     $post->title = 'Title';
     $post->content = 'Content';
+    $post->number = IntEnum::ONE;
 
     expect(fn() => PostPersistence::insert($post))->toThrow(
         MissingOwningRelationException::class,
@@ -137,6 +140,7 @@ test('Must set ID of owning relation', function () {
     $post = new Post();
     $post->title = 'Title';
     $post->content = 'Content';
+    $post->number = IntEnum::ONE;
     $post->author = new User();
 
     expect(fn() => PostPersistence::insert($post))->toThrow(
@@ -153,6 +157,7 @@ test('Can set nullable owning relation to null', function () {
     $post = new Post();
     $post->title = 'Title';
     $post->content = 'Content';
+    $post->number = IntEnum::ONE;
     $post->author = $user;
     $post->editor = null;
 

--- a/tests/Feature/Persistence/PersistenceUpdateTest.php
+++ b/tests/Feature/Persistence/PersistenceUpdateTest.php
@@ -10,6 +10,7 @@ use AdventureTech\ORM\Persistence\PersistenceManager;
 use AdventureTech\ORM\Repository\Repository;
 use AdventureTech\ORM\Tests\TestClasses\Entities\Post;
 use AdventureTech\ORM\Tests\TestClasses\Entities\User;
+use AdventureTech\ORM\Tests\TestClasses\IntEnum;
 use AdventureTech\ORM\Tests\TestClasses\Persistence\PostPersistence;
 use AdventureTech\ORM\Tests\TestClasses\Persistence\UserPersistence;
 use Carbon\CarbonImmutable;
@@ -120,6 +121,7 @@ test('Can update owning relations', function () {
     $post->title = 'Title';
     $post->content = 'Content';
     $post->author = $alice;
+    $post->number = IntEnum::ONE;
     PostPersistence::insert($post);
 
     $post->author = $bob;
@@ -140,6 +142,7 @@ test('Must set ID of non-nullable owning relation', function () {
     $post->title = 'Title';
     $post->content = 'Content';
     $post->author = $alice;
+    $post->number = IntEnum::ONE;
     PostPersistence::insert($post);
 
     $post->author = $bob;
@@ -160,6 +163,7 @@ test('Can set nullable owning relation to null', function () {
     $post->content = 'Content';
     $post->author = $user;
     $post->editor = $user;
+    $post->number = IntEnum::ONE;
     PostPersistence::insert($post);
 
     $post->editor = null;

--- a/tests/Feature/Repositories/RepositoryFilteringTest.php
+++ b/tests/Feature/Repositories/RepositoryFilteringTest.php
@@ -39,9 +39,9 @@ test('Repositories allow filtering of the results', function () {
 test('Can filter within loaded relations', function () {
     $authorId = DB::table('users')->insertGetId(['name' => 'Name']);
     DB::table('posts')->insert([
-        ['id' => 1, 'title' => 'Title', 'content' => 'Content', 'author' => $authorId, 'deleted_at' => null],
-        ['id' => 2, 'title' => 'Other Title', 'content' => 'Content', 'author' => $authorId, 'deleted_at' => null],
-        ['id' => 3, 'title' => 'Title', 'content' => 'Content', 'author' => $authorId, 'deleted' => now()],
+        ['id' => 1, 'title' => 'Title', 'content' => 'Content', 'number' => 1, 'author' => $authorId, 'deleted_at' => null],
+        ['id' => 2, 'title' => 'Other Title', 'content' => 'Content', 'number' => 1, 'author' => $authorId, 'deleted_at' => null],
+        ['id' => 3, 'title' => 'Title', 'content' => 'Content', 'number' => 1, 'author' => $authorId, 'deleted' => now()],
      ]);
     $user = Repository::new(User::class)
         ->with('posts', function (Repository $repository) {
@@ -58,7 +58,7 @@ test('Can filter within loaded relations', function () {
 test('Can filter into loaded relations', function () {
     $authorId = DB::table('users')->insertGetId(['name' => 'Name']);
     DB::table('posts')->insert([
-        ['id' => 1, 'title' => 'Other Title', 'content' => 'Content', 'author' => $authorId, 'deleted_at' => null],
+        ['id' => 1, 'title' => 'Other Title', 'content' => 'Content', 'number' => 1, 'author' => $authorId, 'deleted_at' => null],
     ]);
     $users = Repository::new(User::class)
         ->with('posts')
@@ -70,7 +70,7 @@ test('Can filter into loaded relations', function () {
 test('Can filter out of loaded relations', function () {
     $authorId = DB::table('users')->insertGetId(['name' => 'Name']);
     DB::table('posts')->insert([
-        ['id' => 1, 'title' => 'Other Title', 'content' => 'Content', 'author' => $authorId, 'deleted_at' => null],
+        ['id' => 1, 'title' => 'Other Title', 'content' => 'Content', 'number' => 1, 'author' => $authorId, 'deleted_at' => null],
     ]);
     $user = Repository::new(User::class)
         ->with('posts', function (Repository $repository) {
@@ -84,8 +84,8 @@ test('Can filter out of loaded relations', function () {
 test('Can filter across relations', function () {
     $authorId = DB::table('users')->insertGetId(['name' => 'FOO']);
     DB::table('posts')->insert([
-        ['id' => 1, 'title' => 'FOO', 'content' => 'Content', 'author' => $authorId, 'deleted_at' => null],
-        ['id' => 2, 'title' => 'BAR', 'content' => 'Content', 'author' => $authorId, 'deleted_at' => null],
+        ['id' => 1, 'title' => 'FOO', 'content' => 'Content', 'number' => 1, 'author' => $authorId, 'deleted_at' => null],
+        ['id' => 2, 'title' => 'BAR', 'content' => 'Content', 'number' => 1, 'author' => $authorId, 'deleted_at' => null],
     ]);
     $user = Repository::new(User::class)
         ->with('posts', function (Repository $repository) {

--- a/tests/Feature/Repositories/RepositoryRelationsTest.php
+++ b/tests/Feature/Repositories/RepositoryRelationsTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\DB;
 
 test('Can load relations', function () {
     $authorId = DB::table('users')->insertGetId(['name' => 'Name']);
-    $postId = DB::table('posts')->insertGetId(['title' => 'Title', 'content' => 'Content', 'author' => $authorId]);
+    $postId = DB::table('posts')->insertGetId(['title' => 'Title', 'content' => 'Content', 'author' => $authorId, 'number' => 1]);
     $user = Repository::new(User::class)
         ->with('posts')
         ->find($authorId);
@@ -21,14 +21,14 @@ test('Can load relations', function () {
 
 test('Not loaded relations are not set in the entity', function () {
     $authorId = DB::table('users')->insertGetId(['name' => 'Name']);
-    DB::table('posts')->insertGetId(['title' => 'Title', 'content' => 'Content', 'author' => $authorId]);
+    DB::table('posts')->insertGetId(['title' => 'Title', 'content' => 'Content', 'author' => $authorId, 'number' => 1]);
     $user = Repository::new(User::class)->find($authorId);
     expect(fn() =>$user->posts)->toThrow(Error::class);
 });
 
 test('Can load relations within relations', function () {
     $authorId = DB::table('users')->insertGetId(['name' => 'Name']);
-    DB::table('posts')->insertGetId(['title' => 'Title', 'content' => 'Content', 'author' => $authorId]);
+    DB::table('posts')->insertGetId(['title' => 'Title', 'content' => 'Content', 'author' => $authorId, 'number' => 1]);
     $user = Repository::new(User::class)
         ->with('posts', function (PostRepository $repository) {
             $repository->with('author');

--- a/tests/Feature/Repositories/RepositorySoftDeletesTest.php
+++ b/tests/Feature/Repositories/RepositorySoftDeletesTest.php
@@ -43,10 +43,10 @@ test('Soft-deletes are filtered correctly in loaded relations', function () {
     $authorId = DB::table('users')->insertGetId(['name' => 'FOO']);
     $deletedAuthorId = DB::table('users')->insertGetId(['name' => 'FOO', 'deleted_at' => now()]);
     DB::table('posts')->insert([
-        ['id' => 1, 'title' => 'Title', 'content' => 'Content', 'author' => $authorId, 'deleted_at' => null],
-        ['id' => 2, 'title' => 'Title', 'content' => 'Content', 'author' => $authorId, 'deleted_at' => now()],
-        ['id' => 3, 'title' => 'Title', 'content' => 'Content', 'author' => $deletedAuthorId, 'deleted_at' => null],
-        ['id' => 4, 'title' => 'Title', 'content' => 'Content', 'author' => $deletedAuthorId, 'deleted_at' => now()],
+        ['id' => 1, 'title' => 'Title', 'content' => 'Content', 'number' => 1, 'author' => $authorId, 'deleted_at' => null],
+        ['id' => 2, 'title' => 'Title', 'content' => 'Content', 'number' => 1, 'author' => $authorId, 'deleted_at' => now()],
+        ['id' => 3, 'title' => 'Title', 'content' => 'Content', 'number' => 1, 'author' => $deletedAuthorId, 'deleted_at' => null],
+        ['id' => 4, 'title' => 'Title', 'content' => 'Content', 'number' => 1, 'author' => $deletedAuthorId, 'deleted_at' => now()],
     ]);
     $users = Repository::new(User::class)
         ->with('posts')
@@ -61,10 +61,10 @@ test('Soft-deletes can be deactivated in loaded relations', function () {
     $authorId = DB::table('users')->insertGetId(['name' => 'FOO']);
     $deletedAuthorId = DB::table('users')->insertGetId(['name' => 'FOO', 'deleted_at' => now()]);
     DB::table('posts')->insert([
-        ['id' => 1, 'title' => 'Title', 'content' => 'Content', 'author' => $authorId, 'deleted_at' => null],
-        ['id' => 2, 'title' => 'Title', 'content' => 'Content', 'author' => $authorId, 'deleted_at' => now()],
-        ['id' => 3, 'title' => 'Title', 'content' => 'Content', 'author' => $deletedAuthorId, 'deleted_at' => null],
-        ['id' => 4, 'title' => 'Title', 'content' => 'Content', 'author' => $deletedAuthorId, 'deleted_at' => now()],
+        ['id' => 1, 'title' => 'Title', 'content' => 'Content', 'number' => 1, 'author' => $authorId, 'deleted_at' => null],
+        ['id' => 2, 'title' => 'Title', 'content' => 'Content', 'number' => 1, 'author' => $authorId, 'deleted_at' => now()],
+        ['id' => 3, 'title' => 'Title', 'content' => 'Content', 'number' => 1, 'author' => $deletedAuthorId, 'deleted_at' => null],
+        ['id' => 4, 'title' => 'Title', 'content' => 'Content', 'number' => 1, 'author' => $deletedAuthorId, 'deleted_at' => now()],
     ]);
     $users = Repository::new(User::class)
         ->with('posts', fn(Repository $repository) => $repository->includeSoftDeleted())

--- a/tests/Feature/Repositories/RepositorySortingTest.php
+++ b/tests/Feature/Repositories/RepositorySortingTest.php
@@ -37,15 +37,15 @@ test('Can sort in ascending order within loaded relation', function () {
     shuffle($userData);
     DB::table('users')->insert($userData);
     $postData = [
-        ['title' => 'A1', 'content' => 'content', 'author' => 1],
-        ['title' => 'A2', 'content' => 'content', 'author' => 1],
-        ['title' => 'A3', 'content' => 'content', 'author' => 1],
-        ['title' => 'B1', 'content' => 'content', 'author' => 2],
-        ['title' => 'B2', 'content' => 'content', 'author' => 2],
-        ['title' => 'B3', 'content' => 'content', 'author' => 2],
-        ['title' => 'C1', 'content' => 'content', 'author' => 3],
-        ['title' => 'C2', 'content' => 'content', 'author' => 3],
-        ['title' => 'C3', 'content' => 'content', 'author' => 3],
+        ['title' => 'A1', 'content' => 'content', 'number' => 1, 'author' => 1],
+        ['title' => 'A2', 'content' => 'content', 'number' => 1, 'author' => 1],
+        ['title' => 'A3', 'content' => 'content', 'number' => 1, 'author' => 1],
+        ['title' => 'B1', 'content' => 'content', 'number' => 1, 'author' => 2],
+        ['title' => 'B2', 'content' => 'content', 'number' => 1, 'author' => 2],
+        ['title' => 'B3', 'content' => 'content', 'number' => 1, 'author' => 2],
+        ['title' => 'C1', 'content' => 'content', 'number' => 1, 'author' => 3],
+        ['title' => 'C2', 'content' => 'content', 'number' => 1, 'author' => 3],
+        ['title' => 'C3', 'content' => 'content', 'number' => 1, 'author' => 3],
     ];
     shuffle($postData);
     DB::table('posts')->insert($postData);
@@ -68,15 +68,15 @@ test('Can sort in descending order within loaded relation', function () {
     shuffle($userData);
     DB::table('users')->insert($userData);
     $postData = [
-        ['title' => 'A1', 'content' => 'content', 'author' => 1],
-        ['title' => 'A2', 'content' => 'content', 'author' => 1],
-        ['title' => 'A3', 'content' => 'content', 'author' => 1],
-        ['title' => 'B1', 'content' => 'content', 'author' => 2],
-        ['title' => 'B2', 'content' => 'content', 'author' => 2],
-        ['title' => 'B3', 'content' => 'content', 'author' => 2],
-        ['title' => 'C1', 'content' => 'content', 'author' => 3],
-        ['title' => 'C2', 'content' => 'content', 'author' => 3],
-        ['title' => 'C3', 'content' => 'content', 'author' => 3],
+        ['title' => 'A1', 'content' => 'content', 'number' => 1, 'author' => 1],
+        ['title' => 'A2', 'content' => 'content', 'number' => 1, 'author' => 1],
+        ['title' => 'A3', 'content' => 'content', 'number' => 1, 'author' => 1],
+        ['title' => 'B1', 'content' => 'content', 'number' => 1, 'author' => 2],
+        ['title' => 'B2', 'content' => 'content', 'number' => 1, 'author' => 2],
+        ['title' => 'B3', 'content' => 'content', 'number' => 1, 'author' => 2],
+        ['title' => 'C1', 'content' => 'content', 'number' => 1, 'author' => 3],
+        ['title' => 'C2', 'content' => 'content', 'number' => 1, 'author' => 3],
+        ['title' => 'C3', 'content' => 'content', 'number' => 1, 'author' => 3],
     ];
     shuffle($postData);
     DB::table('posts')->insert($postData);

--- a/tests/TestClasses/Entities/Post.php
+++ b/tests/TestClasses/Entities/Post.php
@@ -10,6 +10,7 @@ use AdventureTech\ORM\Mapping\ManagedColumns\WithTimestamps;
 use AdventureTech\ORM\Mapping\Relations\BelongsTo;
 use AdventureTech\ORM\Mapping\SoftDeletes\WithSoftDeletes;
 use AdventureTech\ORM\Tests\TestClasses\Factories\PostFactory;
+use AdventureTech\ORM\Tests\TestClasses\IntEnum;
 use AdventureTech\ORM\Tests\TestClasses\Repositories\PostRepository;
 use Carbon\CarbonImmutable;
 
@@ -28,6 +29,9 @@ class Post
 
     #[Column]
     public string $content;
+
+    #[Column]
+    public IntEnum $number;
 
     #[DatetimeTZColumn(tzName: 'published_tz')]
     public ?CarbonImmutable $publishedAt;

--- a/tests/TestClasses/IntEnum.php
+++ b/tests/TestClasses/IntEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace AdventureTech\ORM\Tests\TestClasses;
+
+enum IntEnum: int
+{
+    case ONE = 1;
+}

--- a/tests/TestClasses/IntEnum.php
+++ b/tests/TestClasses/IntEnum.php
@@ -5,4 +5,5 @@ namespace AdventureTech\ORM\Tests\TestClasses;
 enum IntEnum: int
 {
     case ONE = 1;
+    case TWO = 2;
 }

--- a/tests/TestClasses/MapperTestClass.php
+++ b/tests/TestClasses/MapperTestClass.php
@@ -11,4 +11,5 @@ class MapperTestClass
     public ?bool $boolProperty;
     public ?CarbonImmutable $datetimeProperty;
     public ?array $jsonProperty;
+    public ?IntEnum $enumProperty;
 }

--- a/tests/Unit/Mapping/Mappers/EnumMapperTest.php
+++ b/tests/Unit/Mapping/Mappers/EnumMapperTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use AdventureTech\ORM\AliasingManagement\AliasingManager;
+use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
+use AdventureTech\ORM\Mapping\Mappers\EnumMapper;
+use AdventureTech\ORM\Tests\TestClasses\IntEnum;
+use AdventureTech\ORM\Tests\TestClasses\MapperTestClass;
+
+test('The enum mapper has a single column', function (EnumMapper $mapper) {
+    expect($mapper->getColumnNames())
+        ->toBeArray()
+        ->toEqualCanonicalizing(['db_column_name']);
+})->with('mapper');
+
+test('The enum mapper can serialize an entity', function (
+    EnumMapper $mapper,
+    ?IntEnum $value,
+    array $expected
+) {
+    expect($mapper->serialize($value))
+        ->toBeArray()
+        ->toEqualCanonicalizing($expected);
+})
+    ->with('mapper')
+    ->with([
+        'null' => [null, ['db_column_name' => null]],
+        'enum value' => [IntEnum::ONE, ['db_column_name' => 1]],
+    ]);
+
+test('The enum mapper can deserialize an item with a null value', function (
+    EnumMapper $mapper,
+    LocalAliasingManager $manager,
+    stdClass $item,
+) {
+    expect($mapper->deserialize($item, $manager))->toBeNull();
+})
+    ->with('mapper')
+    ->with('aliasing manager')
+    ->with([
+        'null' => [(object) ['db_column_name' => null]],
+    ]);
+
+test('The json mapper can deserialize an item with a non-null value', function (
+    EnumMapper $mapper,
+    LocalAliasingManager $manager,
+    stdClass $item,
+    IntEnum $result
+) {
+    expect($mapper->deserialize($item, $manager))
+        ->toEqualCanonicalizing($result);
+})
+    ->with('mapper')
+    ->with('aliasing manager')
+    ->with([
+        'string value' => [(object) ['db_column_name' => '1'], IntEnum::ONE],
+        'int value' => [(object) ['db_column_name' => 1], IntEnum::ONE],
+    ]);
+
+dataset('mapper', function () {
+    $property = new ReflectionProperty(MapperTestClass::class, 'enumProperty');
+    yield new EnumMapper('db_column_name', $property);
+});
+
+dataset('aliasing manager', function () {
+    $mock = Mockery::mock(AliasingManager::class);
+    $mock->shouldReceive('getSelectedColumnName')
+        ->with('db_column_name', 'root')
+        ->andReturn('db_column_name');
+    yield new LocalAliasingManager($mock, 'root');
+});

--- a/tests/Unit/Mapping/Mappers/EnumMapperTest.php
+++ b/tests/Unit/Mapping/Mappers/EnumMapperTest.php
@@ -2,6 +2,7 @@
 
 use AdventureTech\ORM\AliasingManagement\AliasingManager;
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
+use AdventureTech\ORM\Exceptions\EnumSerializationException;
 use AdventureTech\ORM\Mapping\Mappers\EnumMapper;
 use AdventureTech\ORM\Tests\TestClasses\IntEnum;
 use AdventureTech\ORM\Tests\TestClasses\MapperTestClass;
@@ -26,6 +27,21 @@ test('The enum mapper can serialize an entity', function (
         'null' => [null, ['db_column_name' => null]],
         'enum value' => [IntEnum::ONE, ['db_column_name' => 1]],
     ]);
+
+test('The enum mapper throws error when trying to serialize value that is not enum', function (
+    EnumMapper $mapper,
+    mixed $value,
+    array $expected
+) {
+    expect($mapper->serialize($value))
+        ->toBeArray()
+        ->toEqualCanonicalizing($expected);
+})
+    ->with('mapper')
+    ->with([
+        'string value' => ['foo', ['db_column_name' => null]],
+        'object value' => [(object) ['foo' => 'bar'], ['db_column_name' => null]],
+    ])->throws(EnumSerializationException::class);
 
 test('The enum mapper can deserialize an item with a null value', function (
     EnumMapper $mapper,
@@ -55,6 +71,7 @@ test('The json mapper can deserialize an item with a non-null value', function (
         'string value' => [(object) ['db_column_name' => '1'], IntEnum::ONE],
         'int value' => [(object) ['db_column_name' => 1], IntEnum::ONE],
     ]);
+
 
 dataset('mapper', function () {
     $property = new ReflectionProperty(MapperTestClass::class, 'enumProperty');

--- a/tests/database/migrations/2023_05_24_133600_create_posts_table.php
+++ b/tests/database/migrations/2023_05_24_133600_create_posts_table.php
@@ -14,6 +14,7 @@ return new class () extends Migration {
             $table->text('content');
             $table->timestamp('published_at')->nullable();
             $table->string('published_tz')->nullable();
+            $table->enum('number', [1, 2]);
             $table->foreignId('author')->constrained('users');
             $table->foreignId('editor')->nullable()->constrained('users');
             $table->timestamps();


### PR DESCRIPTION
When an entity property is declared a native php enum, the ORM will attempt to map the column value to the corresponding enum.

In addition some tidying up of use statements. Also made the phpunit.xml PhpUnit10 compatible.