### PR TITLE
fix: datetime handling in filters

### DIFF
--- a/src/Repository/Filters/Where.php
+++ b/src/Repository/Filters/Where.php
@@ -3,18 +3,24 @@
 namespace AdventureTech\ORM\Repository\Filters;
 
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
 
 readonly class Where implements Filter
 {
+    private readonly mixed $value;
+
     /**
      * @param  string  $column
      * @param  IS  $operator
      * @param  mixed  $value
      */
-    public function __construct(private string $column, private IS $operator, private mixed $value)
+    public function __construct(private string $column, private IS $operator, mixed $value)
     {
+        $this->value = $value instanceof CarbonInterface
+            ? $value->toIso8601String()
+            : $value;
     }
 
     public function applyFilter(JoinClause|Builder $query, LocalAliasingManager $aliasingManager): void

--- a/src/Repository/Filters/WhereIn.php
+++ b/src/Repository/Filters/WhereIn.php
@@ -3,17 +3,26 @@
 namespace AdventureTech\ORM\Repository\Filters;
 
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
 
 readonly class WhereIn implements Filter
 {
+    private readonly mixed $values;
+
     /**
      * @param  string  $column
      * @param  mixed  $values
      */
-    public function __construct(private string $column, private mixed $values)
+    public function __construct(private string $column, mixed $values)
     {
+        foreach ($values as $index => $value) {
+            if ($value instanceof CarbonInterface) {
+                $values[$index] = $value->toIso8601String();
+            }
+        }
+        $this->values = $values;
     }
 
     public function applyFilter(JoinClause|Builder $query, LocalAliasingManager $aliasingManager,): void

--- a/src/Repository/Filters/WhereIn.php
+++ b/src/Repository/Filters/WhereIn.php
@@ -3,6 +3,7 @@
 namespace AdventureTech\ORM\Repository\Filters;
 
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
+use ArrayAccess;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
@@ -13,9 +14,9 @@ readonly class WhereIn implements Filter
 
     /**
      * @param  string  $column
-     * @param  mixed  $values
+     * @param  iterable<mixed>&ArrayAccess<mixed,mixed>  $values
      */
-    public function __construct(private string $column, mixed $values)
+    public function __construct(private string $column, iterable $values)
     {
         foreach ($values as $index => $value) {
             if ($value instanceof CarbonInterface) {

--- a/src/Repository/Filters/WhereNot.php
+++ b/src/Repository/Filters/WhereNot.php
@@ -3,18 +3,24 @@
 namespace AdventureTech\ORM\Repository\Filters;
 
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
 
 readonly class WhereNot implements Filter
 {
+    private readonly mixed $value;
+
     /**
      * @param  string  $column
      * @param  IS  $operator
      * @param  mixed  $value
      */
-    public function __construct(private string $column, private IS $operator, private mixed $value)
+    public function __construct(private string $column, private IS $operator, mixed $value)
     {
+        $this->value = $value instanceof CarbonInterface
+            ? $value->toIso8601String()
+            : $value;
     }
 
     public function applyFilter(JoinClause|Builder $query, LocalAliasingManager $aliasingManager): void

--- a/src/Repository/Filters/WhereNotIn.php
+++ b/src/Repository/Filters/WhereNotIn.php
@@ -3,6 +3,7 @@
 namespace AdventureTech\ORM\Repository\Filters;
 
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
+use ArrayAccess;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
@@ -13,9 +14,9 @@ readonly class WhereNotIn implements Filter
 
     /**
      * @param  string  $column
-     * @param  mixed  $values
+     * @param  iterable<mixed>&ArrayAccess<mixed,mixed>  $values
      */
-    public function __construct(private string $column, mixed $values)
+    public function __construct(private string $column, iterable $values)
     {
         foreach ($values as $index => $value) {
             if ($value instanceof CarbonInterface) {

--- a/src/Repository/Filters/WhereNotIn.php
+++ b/src/Repository/Filters/WhereNotIn.php
@@ -3,17 +3,26 @@
 namespace AdventureTech\ORM\Repository\Filters;
 
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\JoinClause;
 
 readonly class WhereNotIn implements Filter
 {
+    private readonly mixed $values;
+
     /**
      * @param  string  $column
      * @param  mixed  $values
      */
-    public function __construct(private string $column, private mixed $values)
+    public function __construct(private string $column, mixed $values)
     {
+        foreach ($values as $index => $value) {
+            if ($value instanceof CarbonInterface) {
+                $values[$index] = $value->toIso8601String();
+            }
+        }
+        $this->values = $values;
     }
 
     public function applyFilter(JoinClause|Builder $query, LocalAliasingManager $aliasingManager,): void

--- a/tests/Unit/Repository/Filters/WhereInTest.php
+++ b/tests/Unit/Repository/Filters/WhereInTest.php
@@ -2,22 +2,36 @@
 
 use AdventureTech\ORM\AliasingManagement\AliasingManager;
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
-use AdventureTech\ORM\Repository\Filters\IS;
 use AdventureTech\ORM\Repository\Filters\WhereIn;
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\DB;
 
-test('Filter gets applied correctly', function () {
+test('Filter gets applied correctly', function (array $value, array $expected) {
     $mock = Mockery::mock(AliasingManager::class);
     $mock->shouldReceive('getQualifiedColumnName')
         ->with('column', 'root')
         ->andReturn('qualified.column');
 
-    $filter = new WhereIn('column', ['value_a', 'value_b']);
+    $filter = new WhereIn('column', $value);
 
     $query = DB::query();
 
     $filter->applyFilter($query, new LocalAliasingManager($mock, 'root'));
     expect($query)
         ->toSql()->toBe('select * where "qualified"."column" in (?, ?)')
-        ->getBindings()->toEqualCanonicalizing(['value_a', 'value_b']);
-});
+        ->getBindings()->toEqualCanonicalizing($expected);
+})->with([
+    [
+        [ 'value_a', 'value_b' ],
+        [ 'value_a', 'value_b' ],
+    ],
+    [
+        [ Carbon::parse('2021-01-01 12:00+01'), CarbonImmutable::parse('2023-01-01 12:00:55.99') ],
+        [ '2021-01-01T12:00:00+01:00', '2023-01-01T12:00:55+00:00' ],
+    ],
+    [
+        [ Carbon::parse('2021-01-31 12:00-01'), true ],
+        [ '2021-01-31T12:00:00-01:00', true ],
+    ],
+]);

--- a/tests/Unit/Repository/Filters/WhereNotInTest.php
+++ b/tests/Unit/Repository/Filters/WhereNotInTest.php
@@ -3,20 +3,35 @@
 use AdventureTech\ORM\AliasingManagement\AliasingManager;
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
 use AdventureTech\ORM\Repository\Filters\WhereNotIn;
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\DB;
 
-test('Filter gets applied correctly', function () {
+test('Filter gets applied correctly', function (array $value, array $expected) {
     $mock = Mockery::mock(AliasingManager::class);
     $mock->shouldReceive('getQualifiedColumnName')
         ->with('column', 'root')
         ->andReturn('qualified.column');
 
-    $filter = new WhereNotIn('column', ['value_a', 'value_b']);
+    $filter = new WhereNotIn('column', $value);
 
     $query = DB::query();
 
     $filter->applyFilter($query, new LocalAliasingManager($mock, 'root'));
     expect($query)
         ->toSql()->toBe('select * where "qualified"."column" not in (?, ?)')
-        ->getBindings()->toEqualCanonicalizing(['value_a', 'value_b']);
-});
+        ->getBindings()->toEqualCanonicalizing($expected);
+})->with([
+    [
+        [ 'value_a', 'value_b' ],
+        [ 'value_a', 'value_b' ],
+    ],
+    [
+        [ Carbon::parse('2021-01-01 12:00+01'), CarbonImmutable::parse('2023-01-01 12:00:55.99') ],
+        [ '2021-01-01T12:00:00+01:00', '2023-01-01T12:00:55+00:00' ],
+    ],
+    [
+        [ Carbon::parse('2021-01-31 12:00-01'), true ],
+        [ '2021-01-31T12:00:00-01:00', true ],
+    ],
+]);

--- a/tests/Unit/Repository/Filters/WhereNotTest.php
+++ b/tests/Unit/Repository/Filters/WhereNotTest.php
@@ -4,20 +4,30 @@ use AdventureTech\ORM\AliasingManagement\AliasingManager;
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
 use AdventureTech\ORM\Repository\Filters\IS;
 use AdventureTech\ORM\Repository\Filters\WhereNot;
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\DB;
 
-test('Filter gets applied correctly', function () {
+test('Filter gets applied correctly', function (mixed $value, string $expected) {
     $mock = Mockery::mock(AliasingManager::class);
     $mock->shouldReceive('getQualifiedColumnName')
         ->with('column', 'root')
         ->andReturn('qualified.column');
 
-    $filter = new WhereNot('column', IS::EQUAL, 'value');
+    $filter = new WhereNot('column', IS::EQUAL, $value);
 
     $query = DB::query();
 
     $filter->applyFilter($query, new LocalAliasingManager($mock, 'root'));
     expect($query)
         ->toSql()->toBe('select * where not "qualified"."column" = ?')
-        ->getBindings()->toEqualCanonicalizing(['value']);
-});
+        ->getBindings()->toEqualCanonicalizing([$expected]);
+})->with([
+    ['value', 'value'],
+    [CarbonImmutable::parse('2023-01-01 12:00+01:00'), '2023-01-01T12:00:00+01:00'],
+    [CarbonImmutable::parse('2023-01-01T12:00:53.99-01:00'), '2023-01-01T12:00:53-01:00'],
+    [CarbonImmutable::parse('2023-01-01 12:00'), '2023-01-01T12:00:00+00:00'],
+    [Carbon::parse('2023-01-01 12:00+01:00'), '2023-01-01T12:00:00+01:00'],
+    [Carbon::parse('2023-01-01T12:00:53.99-01:00'), '2023-01-01T12:00:53-01:00'],
+    [Carbon::parse('2023-01-01 12:00'), '2023-01-01T12:00:00+00:00'],
+]);

--- a/tests/Unit/Repository/Filters/WhereTest.php
+++ b/tests/Unit/Repository/Filters/WhereTest.php
@@ -4,20 +4,30 @@ use AdventureTech\ORM\AliasingManagement\AliasingManager;
 use AdventureTech\ORM\AliasingManagement\LocalAliasingManager;
 use AdventureTech\ORM\Repository\Filters\IS;
 use AdventureTech\ORM\Repository\Filters\Where;
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\DB;
 
-test('Filter gets applied correctly', function () {
+test('Filter gets applied correctly', function (mixed $value, string $expected) {
     $mock = Mockery::mock(AliasingManager::class);
     $mock->shouldReceive('getQualifiedColumnName')
         ->with('column', 'root')
         ->andReturn('qualified.column');
 
-    $filter = new Where('column', IS::LIKE, 'value');
+    $filter = new Where('column', IS::LIKE, $value);
 
     $query = DB::query();
 
     $filter->applyFilter($query, new LocalAliasingManager($mock, 'root'));
     expect($query)
         ->toSql()->toBe('select * where "qualified"."column" like ?')
-        ->getBindings()->toEqualCanonicalizing(['value']);
-});
+        ->getBindings()->toEqualCanonicalizing([$expected]);
+})->with([
+    ['value', 'value'],
+    [CarbonImmutable::parse('2023-01-01 12:00+01:00'), '2023-01-01T12:00:00+01:00'],
+    [CarbonImmutable::parse('2023-01-01T12:00:53.99-01:00'), '2023-01-01T12:00:53-01:00'],
+    [CarbonImmutable::parse('2023-01-01 12:00'), '2023-01-01T12:00:00+00:00'],
+    [Carbon::parse('2023-01-01 12:00+01:00'), '2023-01-01T12:00:00+01:00'],
+    [Carbon::parse('2023-01-01T12:00:53.99-01:00'), '2023-01-01T12:00:53-01:00'],
+    [Carbon::parse('2023-01-01 12:00'), '2023-01-01T12:00:00+00:00'],
+]);


### PR DESCRIPTION
Laravel's internal query builder ignores timezone information on `CarbonInterface` instances. This only works if the application runs in local time only (which is not the recommended way of handling datetimes).

This was mitigated by calling the `toIso8601String()` before passing the values on to the query builder.