### PR TITLE
Fix/update type casting bug

### DIFF
--- a/src/Caching/ColumnTypeCache.php
+++ b/src/Caching/ColumnTypeCache.php
@@ -21,11 +21,11 @@ class ColumnTypeCache
         $cached =  Cache::get(self::getColumnTypesCacheKey(), []);
         if (!isset($cached[$table])) {
             $cached[$table] = DB::table('information_schema.columns')
-                ->select(['column_name', 'data_type'])
+                ->select(['column_name', 'udt_name'])
                 ->where('table_name', $table)
                 ->orderBy('ordinal_position')
                 ->get()
-                ->pluck('data_type', 'column_name')
+                ->pluck('udt_name', 'column_name')
                 ->toArray();
         }
         Cache::set(self::getColumnTypesCacheKey(), $cached);

--- a/src/Persistence/Persistors/UpdatePersistor.php
+++ b/src/Persistence/Persistors/UpdatePersistor.php
@@ -9,7 +9,6 @@ use AdventureTech\ORM\Persistence\Persistors\Traits\SerializesEntities;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use JsonException;
 
 use function array_keys;
 use function collect;
@@ -104,7 +103,8 @@ class UpdatePersistor implements Persistor
         $sql = sprintf(
             "UPDATE \"%s\" SET %s FROM (VALUES (%s)) AS %s (\"%s\") WHERE \"%s\".\"%s\" = \"%s\".\"%s\"",
             $tableName,
-            $columns->filter(fn($column) => $column !== $this->entityReflection->getIdColumn())
+            $columns
+                ->filter(fn($column) => $column !== $this->entityReflection->getIdColumn())
                 ->implode(fn ($column) => array_key_exists($column, $managedColumns)
                     ? "\"$column\" = COALESCE(\"$tmpTableName\".\"$column\", \"$tableName\".\"$column\")"
                     : "\"$column\" = \"$tmpTableName\".\"$column\"", ', '),

--- a/tests/Feature/Caching/ColumnTypeCacheTest.php
+++ b/tests/Feature/Caching/ColumnTypeCacheTest.php
@@ -15,22 +15,22 @@ test('Getting works correctly', function () {
     expect(Cache::get('adventure-tech.orm.cache.column-types'))->toBeNull()
         ->and($dbCount)->toBe(0)
         ->and(ColumnTypeCache::get('users'))->toEqual([
-            'id' => 'bigint',
-            'name' => 'character varying',
-            'favourite_color' => 'character varying',
-            'created_at' => 'timestamp with time zone',
-            'updated_at' => 'timestamp with time zone',
-            'deleted_at' => 'timestamp with time zone',
+            'id' => 'int8',
+            'name' => 'varchar',
+            'favourite_color' => 'varchar',
+            'created_at' => 'timestamptz',
+            'updated_at' => 'timestamptz',
+            'deleted_at' => 'timestamptz',
         ])
         ->and($dbCount)->toBe(1)
         ->and(Cache::get('adventure-tech.orm.cache.column-types'))->toHaveCount(1)->toHaveKey('users')
         ->and(ColumnTypeCache::get('users'))->toEqual([
-            'id' => 'bigint',
-            'name' => 'character varying',
-            'favourite_color' => 'character varying',
-            'created_at' => 'timestamp with time zone',
-            'updated_at' => 'timestamp with time zone',
-            'deleted_at' => 'timestamp with time zone',
+            'id' => 'int8',
+            'name' => 'varchar',
+            'favourite_color' => 'varchar',
+            'created_at' => 'timestamptz',
+            'updated_at' => 'timestamptz',
+            'deleted_at' => 'timestamptz',
         ])
         ->and($dbCount)->toBe(1);
 });

--- a/tests/Feature/Persistence/PersistenceUpdateTest.php
+++ b/tests/Feature/Persistence/PersistenceUpdateTest.php
@@ -7,11 +7,14 @@ use AdventureTech\ORM\Repository\Repository;
 use AdventureTech\ORM\Tests\TestCase;
 use AdventureTech\ORM\Tests\TestClasses\BackedEnum;
 use AdventureTech\ORM\Tests\TestClasses\Entities\Post;
+use AdventureTech\ORM\Tests\TestClasses\Entities\Select;
 use AdventureTech\ORM\Tests\TestClasses\Entities\User;
 use AdventureTech\ORM\Tests\TestClasses\Persistence\PostPersistence;
+use AdventureTech\ORM\Tests\TestClasses\Persistence\SelectPersistence;
 use AdventureTech\ORM\Tests\TestClasses\Persistence\UserPersistence;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 test('Cannot use base persistence manager to update entities', function () {
     $user = new User();
@@ -200,4 +203,22 @@ test('Updating skips soft-deleted entities', function () {
         'Could not update all entities. Updated 1 out of 2.'
     )
         ->and(DB::table('users')->where('name', 'NEW')->count())->toBe(1);
+});
+
+test('updating works with table and column names equal to SQL keywords', function () {
+    DB::table('select')->insert([
+        'id' => 1,
+        'end' => Str::ulid(),
+    ]);
+    $ulid = Str::ulid();
+    $entity = new Select();
+    $entity->id = 1;
+    $entity->end = $ulid;
+
+    SelectPersistence::update($entity);
+
+    $this->assertDatabaseHas('select', [
+        'id' => 1,
+        'end' => $ulid,
+    ]);
 });

--- a/tests/TestClasses/Entities/Select.php
+++ b/tests/TestClasses/Entities/Select.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AdventureTech\ORM\Tests\TestClasses\Entities;
+
+use AdventureTech\ORM\Mapping\Columns\Column;
+use AdventureTech\ORM\Mapping\Entity;
+use AdventureTech\ORM\Mapping\Id;
+use AdventureTech\ORM\Mapping\SoftDeletes\WithSoftDeletes;
+
+#[Entity(table: 'select')]
+class Select
+{
+    use WithSoftDeletes;
+
+    #[Id]
+    #[Column]
+    public int $id;
+
+    #[Column]
+    public string $end;
+}

--- a/tests/TestClasses/Persistence/SelectPersistence.php
+++ b/tests/TestClasses/Persistence/SelectPersistence.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace AdventureTech\ORM\Tests\TestClasses\Persistence;
+
+use AdventureTech\ORM\Persistence\PersistenceManager;
+use AdventureTech\ORM\Tests\TestClasses\Entities\Select;
+
+/**
+ * @extends PersistenceManager<Select>
+ */
+class SelectPersistence extends PersistenceManager
+{
+    protected static function getEntityClassName(): string
+    {
+        return Select::class;
+    }
+}

--- a/tests/database/migrations/2024_02_01_100120_create_sql_collision_entities_table.php
+++ b/tests/database/migrations/2024_02_01_100120_create_sql_collision_entities_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    private const TABLE_NAME = 'select';
+    public function up(): void
+    {
+        Schema::create(self::TABLE_NAME, static function (Blueprint $table) {
+            $table->id();
+            $table->ulid('end');
+            $table->softDeletesTz();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists(self::TABLE_NAME);
+    }
+};


### PR DESCRIPTION
Fixes the following bugs when updating:
- table names or column names where not properly escaped, i.e. a when clashing with reserved SQL keywords an SQL exception was thrown
- using `data_type` column from `information_schema.columns` table is insufficient when dealing with fixed length character types such as `bpchar(26)` used by laravel for `ulid` columns. Instead we now use `udt_name` which seems more reliable 